### PR TITLE
Fix line sampling tutorial

### DIFF
--- a/COSSANXengine/examples/Tutorials/CossanObjects/TutorialLineSampling.m
+++ b/COSSANXengine/examples/Tutorials/CossanObjects/TutorialLineSampling.m
@@ -105,7 +105,7 @@ Xout2.plotLines('Stitle','LineSampling + LocalMonteCarlo');
 
 % Change the important direction (defined in the Gradient object in the
 % field Valpha)
-Xgrad=Sensitivity.gradientFiniteDifferences('Xtarget',Xpm,'Coutputname',{'Vg'});
+Xgrad=LocalSensitivityFiniteDifference('Xtarget',Xpm,'Coutputnames',{'Vg'}).computeGradient;
 Xls=LineSampling('Nlines',20,'Xgradient',Xgrad);
 
 % Change the number of batches and number of lines


### PR DESCRIPTION
Change command to compute the importance direction by local sensitivity gradient

Not too sure what the original aim of the tutorial was, but this seems to fix it.

Fixes issue #3  