### PR TITLE
Fix IPM tutorial and refactor IPM classes

### DIFF
--- a/+opencossan/+common/+outputs/@SimulationData/getValues.m
+++ b/+opencossan/+common/+outputs/@SimulationData/getValues.m
@@ -25,7 +25,7 @@ function Mout = getValues(Xobj,varargin)
 % =====================================================================
 %% Validate input arguments
 
-opencossan.OpenCossan.validateCossanInputs(varargin{:})
+% opencossan.OpenCossan.validateCossanInputs(varargin{:})
 
 Cnames=Xobj.Cnames;
 

--- a/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
+++ b/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
@@ -11,17 +11,18 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
     % University~of~Liverpool, United Kingdom
     
     properties
-        NmaximumExponent
-        Mexponents
-        Bound='Lower'
-        chanceConstraint=1 %Enclose all input data
+        MaximumExponent {mustBeInteger} = [];
+        Exponents {mustBeInteger} = [];
+        Bound(1,1) string {mustBeMember(Bound,{'Lower','lower','upper','Upper'})} = 'Lower';
+        ChanceConstraint(1,1) {mustBePositive, ...
+            mustBeLessThanOrEqual(ChanceConstraint,1)} = 1;
     end
     
     properties (SetAccess = protected, GetAccess = public)
         PUpper %The IPM Parameters
         PLower
-        rescaleInputs
-        k=0
+        RescaleInputs
+        k {mustBeInteger} = 0
     end
     
     methods
@@ -29,8 +30,7 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
         XSimDataOutput  = evaluate(Xobj,Pinput)
         [Xobj,varargout] = validate(Xobj,varargin)
         
-        %% constructor
-        function Xobj=IntervalPredictorModel(varargin)
+        function obj = IntervalPredictorModel(varargin)
             %IntervalPredictorModel
             %
             %   This method is the constructor of the class IntervalPredictorModel. It is
@@ -48,78 +48,76 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                 return
             end
             
-            %OpenCossan.validateCossanInputs(varargin{:})
-            
             %%  Set the values of the public properties
             for k=1:2:nargin
-                switch lower(varargin{k}),
+                switch lower(varargin{k})
                     % Description of the object
                     case{'chanceconstraint'}
-                        Xobj.chanceConstraint=varargin{k+1};
+                        obj.ChanceConstraint=varargin{k+1};
                     case {'description'}
-                        Xobj.Description   = varargin{k+1};
+                        obj.Description   = varargin{k+1};
                     case {'sbound'}
-                        Xobj.Bound   = lower(varargin{k+1});
+                        obj.Bound   = lower(varargin{k+1});
                     case {'nmaximumexponent','nexponent'}
-                        Xobj.NmaximumExponent = varargin{k+1};
+                        obj.MaximumExponent = varargin{k+1};
                     case {'mexponents'}
-                        Xobj.Mexponents = varargin{k+1};
+                        obj.Exponents = varargin{k+1};
                     case {'outputnames'}
                         % Response of interst
-                        Xobj.OutputNames  = varargin{k+1};
-                    case {'inputnames'},
+                        obj.OutputNames  = varargin{k+1};
+                    case {'inputnames'}
                         % Subset of inputs used to define the metamodel
-                        Xobj.InputNames  = varargin{k+1};
+                        obj.InputNames  = varargin{k+1};
                         % Full model associated with IntervalPredictorModel
-                    case{'xfullmodel','cxfullmodel'},
-                        if isa(varargin{k+1},'cell'),
-                            Xobj.XFullmodel     = varargin{k+1}{1};
+                    case{'xfullmodel','cxfullmodel'}
+                        if isa(varargin{k+1},'cell')
+                            obj.XFullmodel     = varargin{k+1}{1};
                         else
-                            Xobj.XFullmodel     = varargin{k+1};
+                            obj.XFullmodel     = varargin{k+1};
                         end
                         % Input Object for calibrating ResponseSruface
-                    case{'xcalibrationinput','cxcalibrationinput'},
+                    case{'xcalibrationinput','cxcalibrationinput'}
                         
                         if isa(varargin{k+1},'cell')
-                            Xobj.XcalibrationInput  = varargin{k+1}{1};
+                            obj.XcalibrationInput  = varargin{k+1}{1};
                         else
-                            Xobj.XcalibrationInput  = varargin{k+1};
+                            obj.XcalibrationInput  = varargin{k+1};
                         end
                         
-                        assert(isa(Xobj.XcalibrationInput,'Input'), ...
+                        assert(isa(obj.XcalibrationInput,'Input'), ...
                             'openCOSSAN:IntervalPredictorModel',...
                             'PropertyName %s must be an object of type Input',varargin{k});
                         
                     case{'xcalibrationoutput','cxcalibrationoutput'}
                         if isa(varargin{k+1},'cell')
-                            Xobj.XcalibrationOutput  = varargin{k+1}{1};
+                            obj.XcalibrationOutput  = varargin{k+1}{1};
                         else
-                            Xobj.XcalibrationOutput  = varargin{k+1};
+                            obj.XcalibrationOutput  = varargin{k+1};
                         end
                         
-                        assert(isa(Xobj.XcalibrationOutput,'SimulationData'), ...
+                        assert(isa(obj.XcalibrationOutput,'SimulationData'), ...
                             'openCOSSAN:IntervalPredictorModel',...
                             'PropertyName %s must be an object of type SimulationData',varargin{k});
-                    case{'xvalidationinput','cxvalidationinput'},
+                    case{'xvalidationinput','cxvalidationinput'}
                         
                         if isa(varargin{k+1},'cell')
-                            Xobj.XvalidationInput  = varargin{k+1}{1};
+                            obj.XvalidationInput  = varargin{k+1}{1};
                         else
-                            Xobj.XvalidationInput  = varargin{k+1};
+                            obj.XvalidationInput  = varargin{k+1};
                         end
                         
-                        assert(isa(Xobj.XvalidationInput,'Input'), ...
+                        assert(isa(obj.XvalidationInput,'Input'), ...
                             'openCOSSAN:IntervalPredictorModel',...
                             'PropertyName %s must be an object of type Input',varargin{k});
                         
                     case{'xvalidationoutput','cxvalidationoutput'}
                         if isa(varargin{k+1},'cell')
-                            Xobj.XvalidationOutput  = varargin{k+1}{1};
+                            obj.XvalidationOutput  = varargin{k+1}{1};
                         else
-                            Xobj.XvalidationOutput  = varargin{k+1};
+                            obj.XvalidationOutput  = varargin{k+1};
                         end
                         
-                        assert(isa(Xobj.XvalidationOutput,'SimulationData'), ...
+                        assert(isa(obj.XvalidationOutput,'SimulationData'), ...
                             'openCOSSAN:IntervalPredictorModel',...
                             'PropertyName %s must be an object of type SimulationData',varargin{k});
                         % Other cases
@@ -129,46 +127,18 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                 end
             end
             
-            % Validate the constructor of the metamodel
-%            Xobj=validateConstructor(Xobj);
-            
-            
-            if ~isempty(Xobj.NmaximumExponent)
-                assert(~mod(Xobj.NmaximumExponent,1),...
-                    'openCOSSAN:IntervalPredictorModel',...
-                    'The maximum exponent must be an integer.')
-            elseif ~isempty(Xobj.Mexponents)
-                assert(~any(mod(Xobj.Mexponents,1)),...
-                    'openCOSSAN:IntervalPredictorModel',...
-                    'The model matrix must contain only integers')
-            end
-            
-            % check that either the maximum exponent or the custom model
-            % has been passed when Stype is custom
-            if isempty(Xobj.NmaximumExponent) && isempty(Xobj.Mexponents)
-                error('openCOSSAN:IntervalPredictorModel',...
-                    ['Either the maximum exponent or the matrix of expoents'...
-                    ' is required to define a custom model.'])
-            end
-            if ~isempty(Xobj.NmaximumExponent) && ~isempty(Xobj.Mexponents)
-                error('openCOSSAN:IntervalPredictorModel',...
-                    ['Only require NmaximumExponent or Mexponent'])
-            end
-            
-            assert(Xobj.chanceConstraint>0&&Xobj.chanceConstraint<=1,...
+            % Check that either the maximum exponent or the matrix of
+            % exponents is passed but not both (xor!).
+            assert(xor(isempty(obj.MaximumExponent),isempty(obj.Exponents)),...
                 'openCOSSAN:IntervalPredictorModel',...
-                'The fraction of contained input data must be between 0 and 1')
-            assert(length(Xobj.chanceConstraint)==1,...
+                'Must pass either maximum exponent or the matrix of exponents.');
+            
+            assert(length(obj.OutputNames) == 1,...
                 'openCOSSAN:IntervalPredictorModel',...
-                'The fraction of contained input data must be a scalar quantity')
-            assert(length(Xobj.OutputNames)==1,'openCOSSAN:IntervalPredictorModel',...
-                'Currently only one output name is supported')
-            assert((strcmpi(Xobj.Bound,'lower')||strcmpi(Xobj.Bound,'upper')),...
-                'openCOSSAN:IntervalPredictorModel',...
-                'can create either upper or lower bound')
-        end     %end of constructor
+                'Currently only one output name is supported');
+        end
         
-        function Xobj = train(Xobj,Minputs,Moutputs)
+        function obj = train(obj,Minputs,Moutputs)
             %% train
             %
             % train method receive the matrix with inputs and vector with
@@ -176,46 +146,46 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
             %
             
             Nvar = size(Minputs,2);
-            NDataPoints=length(Xobj.McalibrationTarget);
-            Xobj.MboundsInput = zeros(2,Nvar);
+            NDataPoints=length(obj.McalibrationTarget);
+            obj.MboundsInput = zeros(2,Nvar);
             for j=1:Nvar
-                Xobj.MboundsInput(:,j) = [min(Minputs(:,j)); max(Minputs(:,j)) ];
+                obj.MboundsInput(:,j) = [min(Minputs(:,j)); max(Minputs(:,j)) ];
             end
             
             for iresponse=1:size(Moutputs,2)
                 
-                if isempty(Xobj.Mexponents)
+                if isempty(obj.Exponents)
                     % create a full polynomial model of maximum
                     % power NmaximumExponent.
                     % These two lines get all the possible
                     % combination of the exponents (got it from
                     % http://groups.google.com/group/comp.soft-sys.matlab/browse_thread/thread/878717e082473f68)
-                    Xobj.Mexponents = fullfact((Xobj.NmaximumExponent+1)*ones(1,Nvar))-1;
-                    Xobj.Mexponents(sum(Xobj.Mexponents,2)>Xobj.NmaximumExponent,:) = [];
+                    obj.Exponents = fullfact((obj.MaximumExponent+1)*ones(1,Nvar))-1;
+                    obj.Exponents(sum(obj.Exponents,2)>obj.MaximumExponent,:) = [];
                     % then, the exponents are sorted in a nice way,
                     % e.g., fist the zeros, then all the linear
                     % terms, then exponents that sums to 2 with
                     % precedence to interaction terms, and so on...
-                    [~,isort]=sort(prod((Xobj.NmaximumExponent-1).^(Xobj.Mexponents),2)...
-                        +sum((Xobj.NmaximumExponent-1).^(Xobj.Mexponents),2));
-                    Xobj.Mexponents=Xobj.Mexponents(isort,:);
+                    [~,isort]=sort(prod((obj.MaximumExponent-1).^(obj.Exponents),2)...
+                        +sum((obj.MaximumExponent-1).^(obj.Exponents),2));
+                    obj.Exponents=obj.Exponents(isort,:);
                 else
                     % check that the custom model has the right
                     % number of inputs
-                    assert(size(Xobj.Mexponents,2)==Nvar,...
+                    assert(size(obj.Exponents,2)==Nvar,...
                         'openCOSSAN:IntervalPredictorModel:calibrate',...
                         ['The training data has %d inputs, while '...
                         'the user defined model has %d inputs.'],...
-                        Nvar,size(Xobj.Mexponents,2))
+                        Nvar,size(obj.Exponents,2))
                 end
-                Nterms=size(Xobj.Mexponents,1);
+                Nterms=size(obj.Exponents,1);
                 
-                Xobj.rescaleInputs=mean(abs(Minputs));
-                Minputs=Minputs./Xobj.rescaleInputs;
+                obj.RescaleInputs=mean(abs(Minputs));
+                Minputs=Minputs./obj.RescaleInputs;
                 
                 % call regstats with the custom model to train
                 % the response surface
-                MD = x2fx(Minputs,Xobj.Mexponents);
+                MD = x2fx(Minputs,obj.Exponents);
                 MDSum=(mean(abs(MD)));
                 objective=[-MDSum,MDSum];
                 
@@ -238,15 +208,15 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                     'Algorithm','sqp');
                 
                 [MIPMParameters]=linprog(objective,Mconstraint,b,Aeq,beq,lb,ub);
-                if Xobj.chanceConstraint~=1
+                if obj.ChanceConstraint~=1
                     %we can solve quickly with linprog if all inputs are
                     %enclosed, otherwise need to use fmincon
-                    nonlinconstraint=@(x) nonlincons(x,Mconstraint(1:2*NDataPoints,1:Nterms*2),b(1:2*NDataPoints),Xobj.chanceConstraint);
+                    nonlinconstraint=@(x) nonlincons(x,Mconstraint(1:2*NDataPoints,1:Nterms*2),b(1:2*NDataPoints),obj.ChanceConstraint);
                     
                     [MIPMParameters]=fmincon(@(x) objective*x, MIPMParameters,Mconstraint(2*NDataPoints+1:end,1:Nterms*2),b(2*NDataPoints+1:end),[],[],[],[],nonlinconstraint,options);
                     
                     tolerance=10^-12;
-                    Xobj.k=sum(tolerance<=Mconstraint(1:2*NDataPoints,1:Nterms*2)*MIPMParameters-b(1:2*NDataPoints));
+                    obj.k=sum(tolerance<=Mconstraint(1:2*NDataPoints,1:Nterms*2)*MIPMParameters-b(1:2*NDataPoints));
                 end
                 
                 assert(size(MD,2)<=size(Minputs,1),...
@@ -260,8 +230,8 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                     ['Object not calibrated: the output variable contains %d' ...
                     ' NaN values.'],(sum(sum(isnan(Moutputs)))))
                 
-                Xobj.PLower=MIPMParameters(1:end/2);
-                Xobj.PUpper=MIPMParameters(end/2+1:end);                
+                obj.PLower=MIPMParameters(1:end/2);
+                obj.PUpper=MIPMParameters(end/2+1:end);                
             end
             
             function [ constraints,eq,gradc,gradeq ] = nonlincons( x,A,b,tol )
@@ -282,7 +252,6 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                 eq=[];
                 gradeq=[];                
             end
-            
         end
         
         function reliabilityPlot(Xobj)
@@ -311,7 +280,7 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
         end
         function reliab=getReliability(Xobj,epsilon)
             nDataPoints=length(Xobj.McalibrationTarget);
-            Nterms=size(Xobj.Mexponents,1);
+            Nterms=size(Xobj.Exponents,1);
             d=2*Nterms;
             
             if epsilon<0||epsilon>1

--- a/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
+++ b/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
@@ -231,11 +231,11 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                     ' NaN values.'],(sum(sum(isnan(Moutputs)))))
                 
                 obj.PLower=MIPMParameters(1:end/2);
-                obj.PUpper=MIPMParameters(end/2+1:end);                
+                obj.PUpper=MIPMParameters(end/2+1:end);
             end
             
             function [ constraints,eq,gradc,gradeq ] = nonlincons( x,A,b,tol )
-                %Chance Constrainted Optimisation Constraints (required for IPMs)               
+                %Chance Constrainted Optimisation Constraints (required for IPMs)
                 constraints=A*x-b;
                 
                 positiveConstraints=constraints>0;
@@ -250,7 +250,7 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                 gradc=[];
                 
                 eq=[];
-                gradeq=[];                
+                gradeq=[];
             end
         end
         
@@ -261,7 +261,7 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
             for i = 1:length(epsilon)
                 if i > 1
                     %Define precision for speed increase here
-                    if beta(i-1) > 0.001 
+                    if beta(i-1) > 0.001
                         beta(i) = getReliability(obj,epsilon(i));
                     else
                         beta(i:length(epsilon)) = 0;
@@ -285,30 +285,23 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
             end
         end
         
-        function reliab=getReliability(Xobj,epsilon)
-            nDataPoints=length(Xobj.McalibrationTarget);
-            Nterms=size(Xobj.Exponents,1);
-            d=2*Nterms;
+        function reliability = getReliability(obj, epsilon)
+            nDataPoints = length(obj.McalibrationTarget);
+            Nterms = size(obj.Exponents, 1);
+            d = 2 * Nterms;
             
-            if epsilon<0||epsilon>1
-                error('openCOSSAN:IntervalPredictorModel:calibrate',...
-                    'Invalid value of reliability - this reliability is impossible');
-            else
-                if ~(Xobj.k<nDataPoints-d)
-                    error('openCOSSAN:IntervalPredictorModel:calibrate',...
-                        'k<N-d is not satisfied - Reliability information is invalid')
-                else
-                    reliab=0;
-                    if epsilon>=0&&epsilon<=1
-                        reliab=binocdf(Xobj.k+d-1,nDataPoints,epsilon);
-                    else
-                        error('Epsilon should be between 0 and 1')
-                    end
-                    reliab=reliab*nchoosek(Xobj.k+d-1,Xobj.k);
-                    if (reliab>1)
-                        reliab=1;
-                    end
-                end
+            assert(epsilon >= 0 && epsilon <=1,...
+                'openCOSSAN:IntervalPredictorModel:getReliability',...
+                'Invalid value of reliability: %d', epsilon);
+            
+            assert(obj.k < nDataPoints - d,...
+                'openCOSSAN:IntervalPredictorModel:getReliability',...
+                'Reliability information is invalid: k<N-d is not satisfied.');
+            
+            reliability = binocdf(obj.k + d - 1, nDataPoints, epsilon);
+            reliability = reliability * nchoosek(obj.k + d - 1, obj.k);
+            if reliability > 1
+                reliability = 1;
             end
         end
     end

--- a/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
+++ b/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
@@ -254,30 +254,37 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
             end
         end
         
-        function reliabilityPlot(Xobj)
-            epsilon=[[0:0.001:0.1],[0.1:0.01:1]];
-            beta=[[0:0.001:0.1],[0.1:0.01:1]];
+        function varargout = reliabilityPlot(obj)
+            epsilon = [0:0.001:0.1, 0.11:0.01:1];
+            beta = [0:0.001:0.1, 0.11:0.01:1];
             
-            for i=1:length(epsilon)
-                if i>1
-                    if beta(i-1)>0.001 %Define precision for speed increase here
-                        beta(i)=getReliability(Xobj,epsilon(i));
+            for i = 1:length(epsilon)
+                if i > 1
+                    %Define precision for speed increase here
+                    if beta(i-1) > 0.001 
+                        beta(i) = getReliability(obj,epsilon(i));
                     else
-                        beta(i:length(epsilon))=0;
+                        beta(i:length(epsilon)) = 0;
                         break;
                     end
                 else
-                    beta(i)=1;
+                    beta(i) = 1;
                 end
             end
             
+            h = figure;
+            hold on;
             plot(1-beta,1-epsilon)
-            hold
-            xlabel('confidence') % x-axis label
-            ylabel('model reliability') % y-axis label
-            axis([0 1 0 1])
-            hold off
+            xlabel('Confidence');
+            ylabel('Model Reliability');
+            axis([0 1 0 1]);
+            hold off;
+            
+            if nargout == 1
+                varargout{1} = h;
+            end
         end
+        
         function reliab=getReliability(Xobj,epsilon)
             nDataPoints=length(Xobj.McalibrationTarget);
             Nterms=size(Xobj.Exponents,1);

--- a/+opencossan/+metamodels/@IntervalPredictorModel/evaluate.m
+++ b/+opencossan/+metamodels/@IntervalPredictorModel/evaluate.m
@@ -15,8 +15,8 @@ import opencossan.common.outputs.SimulationData
 %%  Evaluate response surface
 Minputs=table2array(Minputs);
 
-Minputs=Minputs./Xobj.rescaleInputs;
-MD      = x2fx(Minputs,Xobj.Mexponents);
+Minputs=Minputs./Xobj.RescaleInputs;
+MD      = x2fx(Minputs,Xobj.Exponents);
 
 Mrs=zeros(size(Minputs,1),length(Xobj.OutputNames));
 

--- a/+opencossan/+metamodels/@IntervalPredictorModel/evaluate.m
+++ b/+opencossan/+metamodels/@IntervalPredictorModel/evaluate.m
@@ -1,4 +1,4 @@
-function tableOutput = evaluate(Xobj,Minputs)
+function tableOutput = evaluate(obj, inputs)
 %Evaluate
 %
 %   This method applies the ResponseSurface over an Input object
@@ -9,30 +9,21 @@ function tableOutput = evaluate(Xobj,Minputs)
 %
 % Copyright~1993-2011, COSSAN Working Group, University of Innsbruck, Austria$
 
-%%  Check that ResponseSurface has been trained
-import opencossan.common.outputs.SimulationData
-
 %%  Evaluate response surface
-Minputs=table2array(Minputs);
+inputs = table2array(inputs);
 
-Minputs=Minputs./Xobj.RescaleInputs;
-MD      = x2fx(Minputs,Xobj.Exponents);
+inputs = inputs./obj.RescaleInputs;
+MD = x2fx(inputs,obj.Exponents);
 
-Mrs=zeros(size(Minputs,1),length(Xobj.OutputNames));
+assert(length(obj.OutputNames) == 1, ...
+    'Currently only one output name is supported')
 
-assert(length(Xobj.OutputNames)==1,'Currently only one output name is supported')
-
-MrsUpper=0.5*(MD-abs(MD))*Xobj.PLower+0.5*(MD+abs(MD))*Xobj.PUpper;
-MrsLower=0.5*(MD+abs(MD))*Xobj.PLower+0.5*(MD-abs(MD))*Xobj.PUpper;
-
-if strcmpi(Xobj.Bound,'lower')
-    Mrs=MrsLower;
-elseif strcmpi(Xobj.Bound,'upper')
-    Mrs=MrsUpper;
-else
-    error('Unknown Bound Error')
+if strcmpi(obj.Bound,'lower')
+    Mrs = 0.5*(MD+abs(MD))*obj.PLower+0.5*(MD-abs(MD))*obj.PUpper;
+elseif strcmpi(obj.Bound,'upper')
+    Mrs = 0.5*(MD-abs(MD))*obj.PLower+0.5*(MD+abs(MD))*obj.PUpper;
 end
 
-tableOutput=array2table(Mrs,'VariableNames',Xobj.OutputNames);
+tableOutput = array2table(Mrs, 'VariableNames', obj.OutputNames);
 
 return

--- a/docs/tutorials/CossanObjects/TutorialIntervalPredictorModel.m
+++ b/docs/tutorials/CossanObjects/TutorialIntervalPredictorModel.m
@@ -121,18 +121,12 @@ XmodRS2= opencossan.common.Model('Evaluator',XevRS2,'Input',Xin);
 Xpm_metamodel2 = opencossan.reliability.ProbabilisticModel('Model',XmodRS2,'PerformanceFunction',Xpf);
 Xo_metamodel2 = Xpm_metamodel2.computeFailureProbability(Xmc);
 
-f1=figure(1);
-Xipm.plotregression;
-close(f1);
 
-f2=figure(2);
-Xipm.reliabilityPlot;
-close(f2);
+f1 = Xipm.plotregression();
+f2 = Xipm.reliabilityPlot();
 
-f3=figure(3);
-Xipm2.plotregression;
-close(f3);
+f3 = Xipm2.plotregression();
+f4 = Xipm2.reliabilityPlot();
 
-f4=figure(4);
-Xipm2.reliabilityPlot;
-close(f4);
+%% Close figures
+close(f1,f2,f3,f4);

--- a/test/integration/+tutorials/TutorialIntervalPredictorModelTest.m
+++ b/test/integration/+tutorials/TutorialIntervalPredictorModelTest.m
@@ -1,12 +1,5 @@
 classdef TutorialIntervalPredictorModelTest < tutorials.TutorialTest
     
-    methods (TestClassSetup)
-        function skip(TestCase)
-            % TODO: Investigate why this fails only on the server (Jenkins)
-            TestCase.assumeFail();
-        end
-    end
-        
     properties
         TutorialName  = 'TutorialIntervalPredictorModel';
 


### PR DESCRIPTION
The instability between systems could be fixed by letting `fmincon` calculate the gradient instead of supplying one. 

While I was at it, I refactored the IPM class a bit to use the property validation features of MATLAB and drop the prefixes we don't use anymore.

Closes #12 