### PR TITLE
Fix bug type-2 IPM nonlinear constraints

### DIFF
--- a/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
+++ b/+opencossan/+metamodels/@IntervalPredictorModel/IntervalPredictorModel.m
@@ -239,7 +239,7 @@ classdef IntervalPredictorModel < opencossan.metamodels.MetaModel
                 constraints=A*x-b;
                 
                 positiveConstraints=constraints>0;
-                nPositiveConstraints=length(positiveConstraints);
+                nPositiveConstraints=sum(positiveConstraints);
                 
                 [~,I]=sort(constraints);
                 


### PR DESCRIPTION
The number of unsatisfied constraints was calculated incorrectly in the type-2 IPM.